### PR TITLE
fix: update broken links in overview-source.mdx and configuration.mdx

### DIFF
--- a/docs/pages/overview-source.mdx
+++ b/docs/pages/overview-source.mdx
@@ -173,5 +173,5 @@ Contract
 Contract [Prototype Generation Scripts](./overview-source/generation.mdx):
 
 - [`@primodiumxyz/contracts/src/codegen/scripts/CreateTerrain.sol`](https://github.com/primodiumxyz/primodium/blob/main/packages/contracts/src/codegen/scripts/CreateTerrain.sol):
-  [Foundry script](https://book.getfoundry.sh/tutorials/solidity-scripting) for
+  [Foundry script](https://book.getfoundry.sh/guides/scripting-with-solidity) for
   populating terrain ore distribution.

--- a/docs/pages/overview-source/configuration.mdx
+++ b/docs/pages/overview-source/configuration.mdx
@@ -7,7 +7,7 @@ production.
 
 Inspired by [Sky Strife's](https://github.com/latticexyz/skystrife-public)
 templates, we developed internal scripts to generate
-[Foundry scripts](https://book.getfoundry.sh/tutorials/solidity-scripting) from
+[Foundry scripts](https://book.getfoundry.sh/guides/scripting-with-solidity) from
 JSON objects and CSV files with TypeScript scripts. This allows us to quickly
 iterate between play tests without needing to manually update Solidity
 contracts.


### PR DESCRIPTION
## Description
Hi! I fixes broken links in the following files:
1. `overview-source.mdx`: Updated the link to the Foundry scripting guide from `tutorials/solidity-scripting` to `guides/scripting-with-solidity`.
2. `configuration.mdx`: Updated the link to the Foundry scripting guide from `tutorials/solidity-scripting` to `guides/scripting-with-solidity`.

These changes ensure that users are directed to the correct and up-to-date Foundry documentation for Solidity scripting.