### PR TITLE
docs: Fixed minor wording issue in ReadDemo

### DIFF
--- a/examples/WriteDemo/README.md
+++ b/examples/WriteDemo/README.md
@@ -46,7 +46,7 @@ The code should compile with `pnpm build`.
 
 This system is quite a bit more involved.
 
-We start by finding out home asteroid, as seen in the ReadDemo.
+We start by finding our home asteroid, as seen in the ReadDemo.
 
 ### Enumerations
 


### PR DESCRIPTION
I’ve corrected a small error in the text. The phrase "finding out home asteroid" was updated to "finding our home asteroid" for clarity. 